### PR TITLE
Fix package

### DIFF
--- a/rc-mode.el
+++ b/rc-mode.el
@@ -123,10 +123,12 @@
       (previous-line))
     (current-indentation)))
 
+;;;###autoload
 (define-derived-mode rc-mode fundamental-mode "plan9-rc"
   (setq font-lock-defaults '(rc-highlights))
   (setq indent-line-function 'rc-indent-line))
 
+;;;###autoload
 (add-to-list 'auto-mode-alist
              '("\\.rc\\'" . rc-mode))
 

--- a/rc-mode.el
+++ b/rc-mode.el
@@ -132,3 +132,4 @@
              '("\\.rc\\'" . rc-mode))
 
 (provide 'rc-mode)
+;;; rc-mode.el ends here

--- a/rc-mode.el
+++ b/rc-mode.el
@@ -123,8 +123,7 @@
       (previous-line))
     (current-indentation)))
 
-(define-derived-mode rc-mode fundamental-mode
-  (setq mode-name "plan9-rc")
+(define-derived-mode rc-mode fundamental-mode "plan9-rc"
   (setq font-lock-defaults '(rc-highlights))
   (setq indent-line-function 'rc-indent-line))
 

--- a/rc-mode.el
+++ b/rc-mode.el
@@ -130,3 +130,5 @@
 
 (add-to-list 'auto-mode-alist
              '("\\.rc\\'" . rc-mode))
+
+(provide 'rc-mode)

--- a/rc-mode.el
+++ b/rc-mode.el
@@ -38,45 +38,45 @@
 (defun rc-join-string (strings sep)
   (apply #'concat (rc-intersperse strings sep)))
 
-(setq rc-highlights
-      `(("'[^']*'"
-         . font-lock-string-face)
+(defvar rc-highlights
+  `(("'[^']*'"
+     . font-lock-string-face)
         
-        ("#.*$"
-         . font-lock-comment-face)
+    ("#.*$"
+     . font-lock-comment-face)
         
-        (,(rc-join-string '("fn" "break"
-                            "builtin" "cd"
-                            "echo" "eval"
-                            "exec" "exit"
-                            "limit" "newpgrp"
-                            "return" "shift"
-                            "umask" "wait"
-                            "whatis" "\\$#?\\*"
-                            "\\$0" "\\$apids?"
-                            "\\$bqstatus" "\\$cdpath"
-                            "\\$history" "\\$home"
-                            "\\$ifs" "\\$path" "\\$pid"
-                            "\\$prompt" "\\$status"
-                            "\\$version")
-                          "\\|")
-         . font-lock-builtin-face)
+    (,(rc-join-string '("fn" "break"
+                        "builtin" "cd"
+                        "echo" "eval"
+                        "exec" "exit"
+                        "limit" "newpgrp"
+                        "return" "shift"
+                        "umask" "wait"
+                        "whatis" "\\$#?\\*"
+                        "\\$0" "\\$apids?"
+                        "\\$bqstatus" "\\$cdpath"
+                        "\\$history" "\\$home"
+                        "\\$ifs" "\\$path" "\\$pid"
+                        "\\$prompt" "\\$status"
+                        "\\$version")
+                      "\\|")
+     . font-lock-builtin-face)
         
-        (,(rc-join-string '("if" "while" "for" "else" "if not"
-                            "switch"
-                            "@" "=" "&" "&&" "\\^"
-                            "|" ";"
-                            "<<?" ">>?"
-                            "\\(>>?\\|<<?\\||\\)\\[\\d+\\(=\\d+\\)\\]"
-                            "||" "~")
-                          "\\|")
-         . font-lock-keyword-face)
+    (,(rc-join-string '("if" "while" "for" "else" "if not"
+                        "switch"
+                        "@" "=" "&" "&&" "\\^"
+                        "|" ";"
+                        "<<?" ">>?"
+                        "\\(>>?\\|<<?\\||\\)\\[\\d+\\(=\\d+\\)\\]"
+                        "||" "~")
+                      "\\|")
+     . font-lock-keyword-face)
         
-        ("\\(?1:\\$#?\\$*\\w+\\)\\|\\(?1:\\w+\\)[[:space:]]*="
-         1 font-lock-variable-name-face)
+    ("\\(?1:\\$#?\\$*\\w+\\)\\|\\(?1:\\w+\\)[[:space:]]*="
+     1 font-lock-variable-name-face)
 
-        ("!"
-         . font-lock-negation-char-face)))
+    ("!"
+     . font-lock-negation-char-face)))
 
 (defun rc-indent-line ()
   "Indent current line as Plan9 RC shell script"


### PR DESCRIPTION
- Add `provide` statement
- Add package footer for packaging convention
- Fix mode line name argument of define-derived-mode
- Add autoload cookie for lazy loading
- Use `defvar` instead of `setq` for byte-compile warning
